### PR TITLE
Add new "Most Relevant" sort to sort by `score` weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sorts TimesPlus offers and events by named ordering criteria
 `items` should be an array of TimesPlus offers/events that have a `liveDate` and
 either an `eventDate` or an `expiryDate`.
 
-`criteria` can be one of `'Newest'`, `'Ending Soon'`, `'Event Date'`.
+`criteria` can be one of `'Newest'`, `'Ending Soon'`, `'Event Date'`, `'Most Relevant'`.
 
 Returns a new array.
 
@@ -30,6 +30,13 @@ Orders items by the nearest future `expiryDate` or `eventDate`, then items with 
 #### 'Event Date'
 
 Orders items by the nearest future `eventDate`.
+
+#### 'Most Relevant'
+
+Orders items according to their `score` value, as returned by mongo's full text search engine.
+
+Prioritises currently live offers/events and sorts them by score.
+Shifts past offers/events to the bottom of the list and sorts them.
 
 ## Credits
 Built by developers at [Clock](http://clock.co.uk).

--- a/sorter.js
+++ b/sorter.js
@@ -59,6 +59,29 @@ function sort(items, criteria) {
       return a.eventDate - b.eventDate
     })
 
+  case 'Most Relevant':
+
+    function sortScore(a, b) {
+      if (a.score < b.score) return 1
+      if (a.score > b.score) return -1
+
+      // The score must be equal
+      return 0
+    }
+
+    var now = new Date()
+      , pastItems = []
+      , liveItems = []
+
+    items.forEach(function (item) {
+      if (item.expiryDate && item.expiryDate < now) return pastItems.push(item)
+      if (item.eventDate && item.eventDate < now) return pastItems.push(item)
+
+      liveItems.push(item)
+    })
+
+    return liveItems.sort(sortScore).concat(pastItems.sort(sortScore))
+
   default:
     throw new Error('Sort criteria "' + criteria + '" is not supported')
 

--- a/test/fixtures/events.js
+++ b/test/fixtures/events.js
@@ -7,6 +7,7 @@ module.exports.push(
   , title: 'QA with David Beckham'
   , liveDate: moment().subtract('weeks', 1).toDate()
   , eventDate: moment().add('days', 1).add('minutes', 1).toDate()
+  , score: '0.1'
   })
 
 module.exports.push(
@@ -14,6 +15,7 @@ module.exports.push(
   , title: 'Meet the Team'
   , liveDate: moment().subtract('days', 1).add('minutes', 1).toDate()
   , eventDate: moment().add('weeks', 1).toDate()
+  , score: '0.9'
   })
 
 module.exports.push(
@@ -21,6 +23,7 @@ module.exports.push(
   , title: 'An evening with Elvis'
   , liveDate: moment().subtract('years', 45).toDate()
   , eventDate: moment().subtract('years', 44).toDate()
+  , score: '1.2'
   })
 
 module.exports.push(
@@ -28,6 +31,7 @@ module.exports.push(
   , title: 'Eating with posh'
   , liveDate: moment().subtract('months', 1).add('minutes', 1).toDate()
   , eventDate: moment().subtract('days', 1).toDate()
+  , score: '1.6'
   })
 
 module.exports.push(
@@ -35,4 +39,5 @@ module.exports.push(
   , title: 'Question Time'
   , liveDate: moment().subtract('hours', 1).toDate()
   , eventDate: moment().add('months', 1).toDate()
+  , score: '1'
   })

--- a/test/fixtures/offers.js
+++ b/test/fixtures/offers.js
@@ -7,6 +7,7 @@ module.exports.push(
   , title: 'Hypnotist eBook'
   , liveDate: moment().subtract('weeks', 1).add('minutes', 1).toDate()
   , expiryDate: moment().add('days', 1).toDate()
+  , score: '0.1'
   })
 
 module.exports.push(
@@ -14,6 +15,7 @@ module.exports.push(
   , title: 'Win £1,000'
   , liveDate: moment().subtract('days', 1).toDate()
   , expiryDate: moment().add('weeks', 1).toDate()
+  , score: '0.8'
   })
 
 module.exports.push(
@@ -21,6 +23,7 @@ module.exports.push(
   , title: 'Eat Out'
   , liveDate: moment().subtract('weeks', 2).toDate()
   , expiryDate: null
+  , score: '1.1'
   })
 
 module.exports.push(
@@ -28,6 +31,7 @@ module.exports.push(
   , title: 'Win an iPad'
   , liveDate: moment().subtract('months', 1).toDate()
   , expiryDate: moment().add('weeks', 2).toDate()
+  , score: '1.6'
   })
 
 module.exports.push(
@@ -35,4 +39,5 @@ module.exports.push(
   , title: 'Book for £2.99'
   , liveDate: moment().subtract('hours', 1).add('minutes', 1).toDate()
   , expiryDate: moment().add('days', 4).toDate()
+  , score: '0.8'
   })

--- a/test/fixtures/past-offers.js
+++ b/test/fixtures/past-offers.js
@@ -1,0 +1,19 @@
+module.exports = []
+
+var moment = require('moment')
+
+module.exports.push(
+  { _id: 'o6'
+  , title: 'Last week\'s top offer'
+  , liveDate: moment().subtract('weeks', 1).add('minutes', 1).toDate()
+  , expiryDate: moment().subtract('days', 1).toDate()
+  , score: '2'
+  })
+
+module.exports.push(
+  { _id: 'o7'
+  , title: 'Another past good offer'
+  , liveDate: moment().subtract('weeks', 1).toDate()
+  , expiryDate: moment().subtract('days', 1).toDate()
+  , score: '1.8'
+  })

--- a/test/sorter.test.js
+++ b/test/sorter.test.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
   , offerFixtures = require('./fixtures/offers')
+  , pastOffers = require('./fixtures/past-offers')
   , eventFixtures = require('./fixtures/events')
   , sort = require('../')
 
@@ -54,6 +55,23 @@ describe('Sorter', function () {
 
     })
 
+    describe('by criteria: "Most Relevant"', function () {
+
+      it('should order by relevancy score and move past offers to the end', function () {
+
+        var ordered = sort(offerFixtures.concat(pastOffers), 'Most Relevant')
+          , expectedOrder = [ 'o4', 'o3', 'o2', 'o5', 'o1', 'o6', 'o7' ]
+
+        ordered.forEach(function (item, i) {
+          assert.equal(item._id, expectedOrder[i], 'offer ' + item._id + ' is not expected at index ' + i)
+        })
+
+        assert.equal(ordered.length, expectedOrder.length)
+
+      })
+
+    })
+
   })
 
   describe('sorting events', function () {
@@ -80,6 +98,23 @@ describe('Sorter', function () {
       it('should order by most recent liveDate', function () {
 
         var ordered = sort(eventFixtures, 'Newest')
+          , expectedOrder = [ 'e5', 'e2', 'e1', 'e4', 'e3' ]
+
+        ordered.forEach(function (item, i) {
+          assert.equal(item._id, expectedOrder[i], 'event ' + item._id + ' is not expected at index ' + i)
+        })
+
+        assert.equal(ordered.length, expectedOrder.length)
+
+      })
+
+    })
+
+    describe('by criteria: "Most Relevant"', function () {
+
+      it('should order by relevancy score and move past events to the end', function () {
+
+        var ordered = sort(eventFixtures, 'Most Relevant')
           , expectedOrder = [ 'e5', 'e2', 'e1', 'e4', 'e3' ]
 
         ordered.forEach(function (item, i) {
@@ -134,6 +169,24 @@ describe('Sorter', function () {
 
         var ordered = sort([ offerFixtures[2], eventFixtures[2], offerFixtures[2]  ], 'Ending Soon')
           , expectedOrder = [ 'o3', 'o3', 'e3' ]
+
+        ordered.forEach(function (item, i) {
+          assert.equal(item._id, expectedOrder[i], 'item ' + item._id + ' is not expected at index ' + i)
+        })
+
+        assert.equal(ordered.length, expectedOrder.length)
+
+      })
+
+    })
+
+    describe('by criteria: "Most Relevant"', function () {
+
+      it('should order by relevancy score', function () {
+
+        var fixtures = eventFixtures.concat(offerFixtures.concat(pastOffers))
+          , ordered = sort(fixtures, 'Most Relevant')
+          , expectedOrder = [ 'o4', 'o3', 'e5', 'e2', 'o2', 'o5', 'e1', 'o1', 'o6', 'o7', 'e4', 'e3' ]
 
         ordered.forEach(function (item, i) {
           assert.equal(item._id, expectedOrder[i], 'item ' + item._id + ' is not expected at index ' + i)


### PR DESCRIPTION
Currently live offers/events are prioritised over past offers/events.
